### PR TITLE
Bugfix importing user module on runkeeper package

### DIFF
--- a/runkeeper/__init__.py
+++ b/runkeeper/__init__.py
@@ -42,6 +42,6 @@ Here is the basic example of getting total distance for a user
     print total_distance
 """
 
-from runkeeper import User
+from runkeeper.user import User
 
 


### PR DESCRIPTION
Traceback (most recent call last):
  File "runkeeperapi_test.py", line 1, in <module>
    from runkeeper import User
  File "/usr/local/lib/python2.7/dist-packages/runkeeper_api-0.1.1-py2.7.egg/runkeeper/**init**.py", line 45, in <module>
    from runkeeper import User
ImportError: cannot import name User

Easy to solve
